### PR TITLE
split builds and CI updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 build: false
 
-platform:
-  - x86
-  - x64
+configuration:
+  - Debug
+  - Release
 
 environment:
     PYTHON: "C:\\Python27"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,12 @@
 build: false
 
+configuration:
+  - Debug
+  - Release
+
+before_build:
+  - set CONAN_BUILD_TYPES=%CONFIGURATION%
+  
 environment:
     PYTHON: "C:\\Python27"
     PYTHON_VERSION: "2.7.8"
@@ -8,23 +15,11 @@ environment:
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
-          CONAN_BUILD_TYPES: Release
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
-          CONAN_BUILD_TYPES: Debug
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
-          CONAN_BUILD_TYPES: Release
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 12
-          CONAN_BUILD_TYPES: Debug
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 14
-          CONAN_BUILD_TYPES: Release
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
-          CONAN_BUILD_TYPES: Debug
-
+          
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/
   - pip.exe install conan --upgrade

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,10 @@ environment:
 
 matrix:
     fast_finish: true
-    
+
+before_build:
+  - set CONAN_BUILD_TYPES=%CONFIGURATION%
+  
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/
   - pip.exe install conan --upgrade

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,6 @@ build: false
 configuration:
   - Debug
   - Release
-
-before_build:
-  - set CONAN_BUILD_TYPES=%CONFIGURATION%
   
 environment:
     PYTHON: "C:\\Python27"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 build: false
 
-configuration:
-  - Debug
-  - Release
-  
+platform:
+  - x86
+  - x64
+
 environment:
     PYTHON: "C:\\Python27"
     PYTHON_VERSION: "2.7.8"
@@ -17,6 +17,9 @@ environment:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
 
+matrix:
+    fast_finish: true
+    
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/
   - pip.exe install conan --upgrade

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 build: false
 
-configuration:
-  - Debug
-  - Release
+#configuration:
+#  - Debug
+#  - Release
 
 environment:
     PYTHON: "C:\\Python27"
@@ -12,16 +12,19 @@ environment:
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
+          CONAN_BUILD_TYPES: Debug
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Debug
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
 
 matrix:
     fast_finish: true
 
-before_build:
-  - set CONAN_BUILD_TYPES=%CONFIGURATION%
+#before_build:
+#  - set CONAN_BUILD_TYPES=%CONFIGURATION%
   
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 build: false
 
-#configuration:
-#  - Debug
-#  - Release
-
 environment:
     PYTHON: "C:\\Python27"
     PYTHON_VERSION: "2.7.8"
@@ -12,20 +8,23 @@ environment:
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
-          CONAN_BUILD_TYPES: Debug
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_BUILD_TYPES: Release
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
           CONAN_BUILD_TYPES: Debug
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Release
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_BUILD_TYPES: Debug
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Release
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Debug
 
-matrix:
-    fast_finish: true
-
-#before_build:
-#  - set CONAN_BUILD_TYPES=%CONFIGURATION%
-  
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/
   - pip.exe install conan --upgrade

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 build: false
 
+configuration:
+  - Debug
+  - Release
+  
 environment:
     PYTHON: "C:\\Python27"
     PYTHON_VERSION: "2.7.8"

--- a/build.py
+++ b/build.py
@@ -56,7 +56,6 @@ def get_build_types():
     # Only Appveyor has CONFIGURATION, Travis uses both types anyway.
     build_types_a = split_colon_env("CONFIGURATION") or ['Release', 'Debug']
     build_types = split_colon_env("CONAN_BUILD_TYPES") or build_types_a
-
     return build_types
     
 def get_remotes():
@@ -65,11 +64,10 @@ def get_remotes():
     remotes = [ user_remote, bincrafters_remote ]
     
     # If the user supplied a remote manually we give him priority
-    # e.g. maybe he is trying to override the his repo or the bincrafter's repo.
+    # e.g. maybe he is trying to override user_remote or the bincrafters_remote repo.
     remote_env = split_colon_env("CONAN_REMOTES")
     if remote_env:
         remotes = remote_env + remotes
-
     return remotes
     
 if __name__ == "__main__":
@@ -84,7 +82,7 @@ if __name__ == "__main__":
         reference=reference,
         build_types=get_build_types(),
         upload=upload,
-        remotes=get_remotes(),  # while redundant, this moves bincrafters remote to position 0
+        remotes=get_remotes(),
         upload_only_when_stable=True,
         stable_branch_pattern="stable/*")
 

--- a/build.py
+++ b/build.py
@@ -52,10 +52,7 @@ def get_env_vars():
 def get_os():
     return platform.system().replace("Darwin", "Macos")
 
-def get_build_type():
-    print("CONFIGURATION: " + str(os.getenv("CONFIGURATION", ["Release", "Debug"])))
-    return os.getenv("CONFIGURATION", ["Release", "Debug"])
-        
+    
 if __name__ == "__main__":
     name = get_name_from_recipe()
     username, channel, version = get_env_vars()
@@ -66,7 +63,6 @@ if __name__ == "__main__":
         username=username,
         channel=channel,
         reference=reference,
-        build_types=get_build_type(),
         upload=upload,
         remotes=upload,  # while redundant, this moves bincrafters remote to position 0
         upload_only_when_stable=True,

--- a/build.py
+++ b/build.py
@@ -53,7 +53,7 @@ def get_os():
     return platform.system().replace("Darwin", "Macos")
 
 def get_build_type():
-    print("CONFIGURATION: " + os.getenv("CONFIGURATION"))
+    print("CONFIGURATION: " + str(os.getenv("CONFIGURATION", ["Release", "Debug"])))
     return os.getenv("CONFIGURATION", ["Release", "Debug"])
         
 if __name__ == "__main__":

--- a/build.py
+++ b/build.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from conan.packager import ConanMultiPackager
+from conan.packager import ConanMultiPackager, split_colon_env
 import os
 import re
 import platform
@@ -53,15 +53,9 @@ def get_os():
     return platform.system().replace("Darwin", "Macos")
 
 def get_build_types():
-    build_types_a = os.getenv("CONFIGURATION", ['Release', 'Debug'])
-    if type(build_types_a) is not list:
-        build_types = [ build_types_a ]
-    else:
-        build_types = build_types_a
-        
-    build_types_env = os.getenv("CONAN_BUILD_TYPES", "")
-    if build_types_env and type(build_types_env) is not list:
-        build_types = [ build_types_env ]
+    # Only Appveyor has CONFIGURATION, Travis uses both types anyway.
+    build_types_a = split_colon_env("CONFIGURATION") or ['Release', 'Debug']
+    build_types = split_colon_env("CONAN_BUILD_TYPES") or build_types_a
 
     return build_types
     
@@ -72,9 +66,9 @@ def get_remotes():
     
     # If the user supplied a remote manually we give him priority
     # e.g. maybe he is trying to override the his repo or the bincrafter's repo.
-    remote_env = os.getenv("CONAN_REMOTES", "")
+    remote_env = split_colon_env("CONAN_REMOTES")
     if remote_env:
-        remotes.insert(0,remote_env)
+        remotes = remote_env + remotes
 
     return remotes
     

--- a/build.py
+++ b/build.py
@@ -52,10 +52,23 @@ def get_env_vars():
 def get_os():
     return platform.system().replace("Darwin", "Macos")
 
-def get_remotes():
-    bincrafters_remote = 'https://api.bintray.com/conan/bincrafters/public-conan'
-    remotes = [ bincrafters_remote ]
+def get_build_types():
+    build_types_a = os.getenv("CONFIGURATION", ['Release', 'Debug'])
+    build_types = [ build_types_a ]
 
+    build_types_env = os.getenv("CONAN_BUILD_TYPES", "")
+    if build_types_env:
+        build_types = [ build_types_env ]
+
+    return build_types
+    
+def get_remotes():
+    user_remote = "https://api.bintray.com/conan/{0}/public-conan".format(username)
+    bincrafters_remote = 'https://api.bintray.com/conan/bincrafters/public-conan'
+    remotes = [ user_remote, bincrafters_remote ]
+    
+    # If the user supplied a remote manually we give him priority
+    # e.g. maybe he is trying to override the his repo or the bincrafter's repo.
     remote_env = os.getenv("CONAN_REMOTES", "")
     if remote_env:
         remotes.insert(0,remote_env)
@@ -72,6 +85,7 @@ if __name__ == "__main__":
         username=username,
         channel=channel,
         reference=reference,
+        build_types=get_build_types(),
         upload=upload,
         remotes=get_remotes(),  # while redundant, this moves bincrafters remote to position 0
         upload_only_when_stable=True,

--- a/build.py
+++ b/build.py
@@ -54,10 +54,13 @@ def get_os():
 
 def get_build_types():
     build_types_a = os.getenv("CONFIGURATION", ['Release', 'Debug'])
-    build_types = [ build_types_a ]
-
+    if type(build_types_a) is not list:
+        build_types = [ build_types_a ]
+    else
+        build_types = build_types_a
+        
     build_types_env = os.getenv("CONAN_BUILD_TYPES", "")
-    if build_types_env:
+    if build_types_env and type(build_types_env) is not list:
         build_types = [ build_types_env ]
 
     return build_types

--- a/build.py
+++ b/build.py
@@ -53,7 +53,7 @@ def get_os():
     return platform.system().replace("Darwin", "Macos")
 
 def get_build_type():
-    print("CONFIGURATION: " + os.getenv("CONFIGURATION")
+    print("CONFIGURATION: " + os.getenv("CONFIGURATION"))
     return os.getenv("CONFIGURATION", ["Release", "Debug"])
         
 if __name__ == "__main__":

--- a/build.py
+++ b/build.py
@@ -53,6 +53,7 @@ def get_os():
     return platform.system().replace("Darwin", "Macos")
 
 def get_build_type():
+    print("CONFIGURATION: " + os.getenv("CONFIGURATION")
     return os.getenv("CONFIGURATION", ["Release", "Debug"])
         
 if __name__ == "__main__":

--- a/build.py
+++ b/build.py
@@ -52,6 +52,15 @@ def get_env_vars():
 def get_os():
     return platform.system().replace("Darwin", "Macos")
 
+def get_remotes():
+    bincrafters_remote = 'https://api.bintray.com/conan/bincrafters/public-conan'
+    remotes = [ bincrafters_remote ]
+
+    remote_env = os.getenv("CONAN_REMOTES", "")
+    if remote_env:
+        remotes.insert(0,remote_env)
+
+    return remotes
     
 if __name__ == "__main__":
     name = get_name_from_recipe()
@@ -64,7 +73,7 @@ if __name__ == "__main__":
         channel=channel,
         reference=reference,
         upload=upload,
-        remotes=upload,  # while redundant, this moves bincrafters remote to position 0
+        remotes=get_remotes(),  # while redundant, this moves bincrafters remote to position 0
         upload_only_when_stable=True,
         stable_branch_pattern="stable/*")
 

--- a/build.py
+++ b/build.py
@@ -52,7 +52,9 @@ def get_env_vars():
 def get_os():
     return platform.system().replace("Darwin", "Macos")
 
-
+def get_build_type():
+    return os.getenv("CONFIGURATION", ["Release", "Debug"])
+        
 if __name__ == "__main__":
     name = get_name_from_recipe()
     username, channel, version = get_env_vars()
@@ -63,6 +65,7 @@ if __name__ == "__main__":
         username=username,
         channel=channel,
         reference=reference,
+        build_types=get_build_type(),
         upload=upload,
         remotes=upload,  # while redundant, this moves bincrafters remote to position 0
         upload_only_when_stable=True,

--- a/build.py
+++ b/build.py
@@ -56,7 +56,7 @@ def get_build_types():
     build_types_a = os.getenv("CONFIGURATION", ['Release', 'Debug'])
     if type(build_types_a) is not list:
         build_types = [ build_types_a ]
-    else
+    else:
         build_types = build_types_a
         
     build_types_env = os.getenv("CONAN_BUILD_TYPES", "")


### PR DESCRIPTION
This PR fixes a number of issues related to split builds.

It improves:

a) The syntax required in the appveyor.yml is now much simpler (no need to specify Debug/Release per config in the matrix)
b) the build.py generates split builds per build_type (release/debug), but also supports user-overriding through the respective conan env variables. 
c) It creates three levels of remote repository dependency lookups in an order that allows users to override at will:
    1) the user's auto-generated (like before): "https://api.bintray.com/conan/{username}/public-conan"
    2) the bincrafters' bintray repo next: https://api.bintray.com/conan/bincrafters/public-conan
    3) any repos specified through CONAN_REMOTES, which are prepended to the abovementioned repos.

Note that without this approach forking repos like conan-glog and using CI fails if the bincrafters' bintray remote is not added manually. This PR fixes all these.

