### PR TITLE
Don't build as pure C code.

### DIFF
--- a/build.py
+++ b/build.py
@@ -12,7 +12,7 @@ def add_gflags_shared(build):
     
 if __name__ == "__main__":
 
-    builder = build_template_default.get_builder()
+    builder = build_template_default.get_builder(pure_c=False)
     
     builder.builds = map(add_gflags_shared, builder.items)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,7 +40,6 @@ class GlogConan(ConanFile):
         cmake.definitions['BUILD_TESTING'] = False
         if self.settings.os != "Windows":
             cmake.definitions['CMAKE_POSITION_INDEPENDENT_CODE'] = self.options.fPIC
-        cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
         cmake.configure()
         cmake.build()
         cmake.install()


### PR DESCRIPTION
This is a C++ library, so we need to build it for the various
libcxx values that may be encountered.